### PR TITLE
GPIO library fix

### DIFF
--- a/mpio/gpio.py
+++ b/mpio/gpio.py
@@ -380,6 +380,7 @@ class GPIO(object):
             fcntl.ioctl(fd, _GPIO_GET_CHIPINFO_IOCTL, info, True)
             for line_offset in range(info.lines):
                 if offset == pin:
+                    os.close(fd) #when this returns it open a files that it doesnt close
                     return devname, line_offset
                 offset += 1
             os.close(fd)


### PR DESCRIPTION
I was opening a bunch of GPIO objects and closing them but the number of files opened was still going up. i saw that during init it calls pin_lookup which opens the file but when it returns it doesnt close it.